### PR TITLE
Patch lib to work with MongoDB 4.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var BSON;
 var logger;
 var meta;
 
-var documentStore = undefined;
+var documentStore;
 
 var fileSystemDocumentStore = function(root) {
   var dbDir = root;
@@ -513,8 +513,8 @@ function wrapper(my) {
   }
 
   require('mongodb').MongoClient.connect(my.uri, my.options).then(function(database) {
-    const databaseName = database.s.options.dbName;
-    let db = database.db(databaseName);
+    var databaseName = database.s.options.dbName;
+    var db = database.db(databaseName);
 
     logger('db open');
 
@@ -547,7 +547,7 @@ function wrapper(my) {
         documentStore.addCollection('.metadata', go);
       }
     });
-  }).catch((err) => {
+  }).catch(function (err) {
     return callback(err);
   });
 }

--- a/index.js
+++ b/index.js
@@ -573,9 +573,14 @@ function backup(options) {
     }
   }
 
+  var rootPath = opt.root || '';
+  if (rootPath !== '') {
+    rootPath = path.resolve(String(opt.root || ''));
+  }
+
   var my = {
     uri: String(opt.uri),
-    root: path.resolve(String(opt.root || '')) + path.sep,
+    root: rootPath + path.sep,
     stream: opt.stream || null,
     parser: opt.parser || 'bson',
     numCursors: ~~opt.numCursors,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fstream": "1.0.11",
     "graceful-fs": "4.1.11",
     "logger-request": "3.8.0",
-    "mongodb": "2.2.26",
+    "mongodb": "3.1.13",
     "tar-stream": "^1.5.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue: mongo-backup-streaming was working with MongoDB 3.x

After looking at the documentation I was able to make a patch on the library, tons of things got deprecated on new mongodb official package version. In example:


https://stackoverflow.com/a/47694265/467034
http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#snapshot
https://stackoverflow.com/a/50597669/467034